### PR TITLE
enable html formatting in Pushover message

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,12 +76,13 @@ use LeonardoTeixeira\Pushover\Exceptions\PushoverException;
 $client = new Client('YOUR_USER_CODE_HERE', 'YOUR_TOKEN_HERE');
 
 $message = new Message();
-$message->setMessage('Your messsage here.');
+$message->setMessage('Your messsage <b>here</b>.');
 $message->setTitle('Title here');
 $message->setUrl('http://www.example.com/');
 $message->setUrlTitle('Click me!');
 $message->setPriority(Priority::HIGH);
 $message->setSound(Sound::SIREN);
+$message->setHtml(true);
 $message->setDate(new \DateTime());
 
 try {

--- a/examples/complete-example.php
+++ b/examples/complete-example.php
@@ -13,12 +13,13 @@ use LeonardoTeixeira\Pushover\Exceptions\PushoverException;
 $client = new Client('YOUR_USER_CODE_HERE', 'YOUR_TOKEN_HERE');
 
 $message = new Message();
-$message->setMessage('Your messsage here.');
+$message->setMessage('Your messsage <b>here</b>.');
 $message->setTitle('Title here');
 $message->setUrl('http://www.example.com/');
 $message->setUrlTitle('Click me!');
 $message->setPriority(Priority::HIGH);
 $message->setSound(Sound::SIREN);
+$message->setHtml(true);
 $message->setDate(new \DateTime());
 
 try {

--- a/src/LeonardoTeixeira/Pushover/Client.php
+++ b/src/LeonardoTeixeira/Pushover/Client.php
@@ -74,6 +74,10 @@ class Client
         if ($message->hasSound()) {
             $postData['sound'] = $message->getSound();
         }
+        
+        if ($message->hasHtml()) {
+            $postData['html'] = $message->getHtml();
+        }
 
         if ($message->hasDate()) {
             $postData['timestamp'] = $message->getDate()->getTimestamp();

--- a/src/LeonardoTeixeira/Pushover/Client.php
+++ b/src/LeonardoTeixeira/Pushover/Client.php
@@ -74,7 +74,7 @@ class Client
         if ($message->hasSound()) {
             $postData['sound'] = $message->getSound();
         }
-        
+
         if ($message->hasHtml()) {
             $postData['html'] = $message->getHtml();
         }

--- a/src/LeonardoTeixeira/Pushover/Message.php
+++ b/src/LeonardoTeixeira/Pushover/Message.php
@@ -12,6 +12,7 @@ class Message
     private $urlTitle;
     private $priority;
     private $sound;
+    private $html;
     private $date;
 
     public function __construct($message = null, $title = null, $priority = Priority::NORMAL)
@@ -49,6 +50,11 @@ class Message
     public function getSound()
     {
         return $this->sound;
+    }
+    
+    public function getHtml()
+    {
+        return $this->html;
     }
 
     public function getDate()
@@ -91,6 +97,14 @@ class Message
         }
         $this->sound = $sound;
     }
+    
+    public function setHtml($html)
+    {
+        if ($html)
+            $this->html = 1;
+        else
+            $this->html = 0;
+    }
 
     public function setDate(\DateTime $date)
     {
@@ -115,6 +129,11 @@ class Message
     public function hasSound()
     {
         return !is_null($this->sound);
+    }
+    
+    public function hasHtml()
+    {
+        return !is_null($this->html);
     }
 
     public function hasDate()

--- a/src/LeonardoTeixeira/Pushover/Message.php
+++ b/src/LeonardoTeixeira/Pushover/Message.php
@@ -51,7 +51,7 @@ class Message
     {
         return $this->sound;
     }
-    
+
     public function getHtml()
     {
         return $this->html;
@@ -97,7 +97,7 @@ class Message
         }
         $this->sound = $sound;
     }
-    
+
     public function setHtml($html)
     {
         if ($html)
@@ -130,7 +130,7 @@ class Message
     {
         return !is_null($this->sound);
     }
-    
+
     public function hasHtml()
     {
         return !is_null($this->html);

--- a/tests/LeonardoTeixeira/Pushover/MessageTest.php
+++ b/tests/LeonardoTeixeira/Pushover/MessageTest.php
@@ -11,20 +11,22 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $this->messages = [
             [
                 'title' => 'Example Message 1',
-                'message' => 'Example content message 1.',
+                'message' => 'Example content message <b>1</b>.',
                 'url' => 'http://www.google.com/',
                 'url_title' => 'Google',
                 'priority' => - 2,
                 'sound' => 'classical',
+                'html' => 1,
                 'date' => '2014-08-14'
             ],
             [
                 'title' => 'Example Message 2',
-                'message' => 'Example content message 2.',
+                'message' => 'Example content message <b>2</b>.',
                 'url' => 'https://github.com/',
                 'url_title' => 'Github',
                 'priority' => 1,
                 'sound' => 'spacealarm',
+                'html' => 0,
                 'date' => '2014-08-10'
             ]
         ];
@@ -51,6 +53,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
             $m->setUrlTitle($message['url_title']);
             $m->setPriority($message['priority']);
             $m->setSound($message['sound']);
+            $m->setHtml($message['html']);
             $m->setDate(new \DateTime($message['date']));
 
             $this->assertEquals($message['title'], $m->getTitle());
@@ -59,6 +62,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals($message['url_title'], $m->getUrlTitle());
             $this->assertEquals($message['priority'], $m->getPriority());
             $this->assertEquals($message['sound'], $m->getSound());
+            $this->assertEquals($message['html'], $m->getHtml());
             $this->assertEquals($message['date'], $m->getDate()
                 ->format('Y-m-d'));
         }
@@ -76,6 +80,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
             $this->assertFalse($m->hasUrl());
             $this->assertFalse($m->hasUrlTitle());
             $this->assertFalse($m->hasSound());
+            $this->assertFalse($m->hasHtml());
             $this->assertFalse($m->hasDate());
         }
 
@@ -88,12 +93,14 @@ class MessageTest extends \PHPUnit_Framework_TestCase
             $m->setUrlTitle($message['url_title']);
             $m->setPriority($message['priority']);
             $m->setSound($message['sound']);
+            $m->setHtml($message['html']);
             $m->setDate(new \DateTime($message['date']));
 
             $this->assertTrue($m->hasTitle());
             $this->assertTrue($m->hasUrl());
             $this->assertTrue($m->hasUrlTitle());
             $this->assertTrue($m->hasSound());
+            $this->assertTrue($m->hasHtml());
             $this->assertTrue($m->hasDate());
         }
     }


### PR DESCRIPTION
Pushover API does support HTML tags to be able to create more beautiful pushover messages.

This commit enables you to use
`setHtml(true);` to enable html formatting
`setHtml(false);` to remote html formatting

HTML tags currently supported by their API:
`<b>word</b>` - display word in bold
`<i>word</i>` - display word in italics
`<u>word</u>` - display word underlined
`<font color="blue">word</font>` - display word in blue text (most colors and hex codes permitted)
`<a href="http://example.com/">word</a>` - display word as a tappable link to http://example.com/
