### PR TITLE
Support Pushing Images, Poll Receipts, Cancel Emergencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ use LeonardoTeixeira\Pushover\Message;
 use LeonardoTeixeira\Pushover\Priority;
 use LeonardoTeixeira\Pushover\Sound;
 use LeonardoTeixeira\Pushover\Exceptions\PushoverException;
+use LeonardoTeixeira\Pushover\Receipt;
+use LeonardoTeixeira\Pushover\Status;
 
 $client = new Client('YOUR_USER_CODE_HERE', 'YOUR_TOKEN_HERE');
 
@@ -86,8 +88,9 @@ $message->setHtml(true);
 $message->setDate(new \DateTime());
 
 try {
-    $client->push($message);
+    $receipt = $client->push($message);
     echo 'The message has been pushed!', PHP_EOL;
+    $stauts = $client->poll($receipt);
 } catch (PushoverException $e) {
     echo 'ERROR: ', $e->getMessage(), PHP_EOL;
 }
@@ -104,6 +107,8 @@ $message->setRetry(60);
 $message->setExpire(10800);
 $message->setCallback('http://callback-url.com/');
 ```
+
+You can poll the notification status using `poll`.
 
 ## Running the tests
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ $message->setDate(new \DateTime());
 try {
     $receipt = $client->push($message);
     echo 'The message has been pushed!', PHP_EOL;
-    $stauts = $client->poll($receipt);
+    $status = $client->poll($receipt);
 } catch (PushoverException $e) {
     echo 'ERROR: ', $e->getMessage(), PHP_EOL;
 }

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ $message = new Message();
 $message->setMessage('Your messsage <b>here</b>.');
 $message->setTitle('Title here');
 $message->setUrl('http://www.example.com/');
+$message->setAttachment('pic.jpg');
 $message->setUrlTitle('Click me!');
 $message->setPriority(Priority::HIGH);
 $message->setSound(Sound::SIREN);

--- a/src/LeonardoTeixeira/Pushover/Client.php
+++ b/src/LeonardoTeixeira/Pushover/Client.php
@@ -104,27 +104,27 @@ class Client
         if ($message->hasHtml()) {
             $postData['html'] = $message->getHtml();
         }
-		
+
         if ($message->hasDate()) {
             $postData['timestamp'] = $message->getDate()->getTimestamp();
         }
 
-		if ($message->hasAttachment()) {
-			$postData['attachment'] = new \CURLFile(realpath($message->getAttachment()));
-		}
+      if ($message->hasAttachment()) {
+         $postData['attachment'] = new \CURLFile(realpath($message->getAttachment()));
+      }
 
         try {
-			// Using hooks is an ugly hack since we bypass the fancy request API
-			// Up to no, Requests doesn't support multi-part headers :-/
-			//
-			// Should we switch to guzzle/guzzle ?
-			$hooks = new Requests_Hooks();
-			$hooks->register('curl.before_send', function($fp) use ($postData) {
-				curl_setopt($fp, CURLOPT_POSTFIELDS, $postData);
-				$postData = [];
+         // Using hooks is an ugly hack since we bypass the fancy request API
+         // Up to no, Requests doesn't support multi-part headers :-/
+         //
+         // Should we switch to guzzle/guzzle ?
+         $hooks = new Requests_Hooks();
+         $hooks->register('curl.before_send', function($fp) use ($postData) {
+         curl_setopt($fp, CURLOPT_POSTFIELDS, $postData);
+         $postData = [];
             });
             $hooks = ['hooks' => $hooks];
-					
+
             $request = Requests::post(self::API_MESSAGE_URL, [], $postData, $hooks);
             $responseJson = json_decode($request->body);
 

--- a/src/LeonardoTeixeira/Pushover/Client.php
+++ b/src/LeonardoTeixeira/Pushover/Client.php
@@ -11,6 +11,7 @@ class Client
     private $token;
 
     const API_MESSAGE_URL = 'https://api.pushover.net/1/messages.json';
+    const API_RECEIPTS_URL = 'https://api.pushover.net/1/receipts';
 
     public function __construct($user = null, $token = null)
     {
@@ -47,7 +48,7 @@ class Client
         if ($message->getMessage() == null) {
             throw new PushoverException('The message content was not set.');
         }
-        
+
         if ($message->getPriority() == Priority::EMERGENCY) {
             if (!$message->hasRetry()) {
                 throw new PushoverException('The emergency priority must have the \'retry\' parameter.');
@@ -117,8 +118,66 @@ class Client
                     throw new PushoverException('Unable to access the Pushover API.');
                 }
             }
+            if(isset($responseJson->receipt)) {
+                return new Receipt($responseJson->receipt);
+            }
+            return new Receipt();
+
         } catch (\Exception $e) {
             throw new PushoverException($e->getMessage());
         }
     }
+
+    public function poll(Receipt $receipt)
+    {
+        if (! $receipt instanceof Receipt ) {
+            throw new PushoverException('The parameter \'$receipt\' must be a Receipt instance.');
+        }
+        
+        if(is_null($receipt->getReceipt())) {
+            throw new PushoverException('The receipt content was not set.');            
+        }
+
+        try {
+            $request = Requests::get(self::API_RECEIPTS_URL.'/'.$receipt->getReceipt().'.json?token='.$this->token, []);
+            $responseJson = json_decode($request->body, true);
+            
+            if (!isset($responseJson['status']) || $responseJson['status'] != 1) {
+                if (isset($responseJson['errors'])) {
+                    throw new PushoverException($responseJson['errors'][0]);
+                } else {
+                    throw new PushoverException('Unable to access the Pushover API.');
+                }
+            }
+            return new Status($responseJson);
+
+        } catch (\Exception $e) {
+            throw new PushoverException($e->getMessage());
+        }
+    }
+    public function cancel(Receipt $receipt)
+    {
+        if (! $receipt instanceof Receipt ) {
+            throw new PushoverException('The parameter \'$receipt\' must be a Receipt instance.');
+        }
+        
+        if(is_null($receipt->getReceipt())) {
+            throw new PushoverException('The receipt content was not set.');            
+        }
+
+        try {
+            $request = Requests::post(self::API_RECEIPTS_URL.'/'.$receipt->getReceipt().'/cancel.json', [], ['token' => $this->token]);
+            $responseJson = json_decode($request->body, true);
+                        
+            if (!isset($responseJson['status']) || $responseJson['status'] != 1) {
+                if (isset($responseJson['errors'])) {
+                    throw new PushoverException($responseJson['errors'][0]);
+                } else {
+                    throw new PushoverException('Unable to access the Pushover API.');
+                }
+            }
+        } catch (\Exception $e) {
+            throw new PushoverException($e->getMessage());
+        }        
+    }        
 }

--- a/src/LeonardoTeixeira/Pushover/Message.php
+++ b/src/LeonardoTeixeira/Pushover/Message.php
@@ -17,7 +17,8 @@ class Message
     private $sound;
     private $html;
     private $date;
-
+	private $attachment;
+	
     public function __construct($message = null, $title = null, $priority = Priority::NORMAL)
     {
         $this->message = $message;
@@ -80,6 +81,11 @@ class Message
         return $this->date;
     }
 
+	public function getAttachment()
+	{
+		return $this->attachment;
+	}
+	
     public function setMessage($message)
     {
         $this->message = $message;
@@ -144,6 +150,11 @@ class Message
         $this->date = $date;
     }
 
+	public function setAttachment($attachment)
+	{
+		$this->attachment = $attachment;
+	}
+	
     public function hasTitle()
     {
         return !is_null($this->title);
@@ -188,4 +199,9 @@ class Message
     {
         return ($this->date instanceof \DateTime);
     }
+	
+	public function hasAttachment()
+	{
+		return file_exists($this->attachment);
+	}
 }

--- a/src/LeonardoTeixeira/Pushover/Receipt.php
+++ b/src/LeonardoTeixeira/Pushover/Receipt.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace LeonardoTeixeira\Pushover;
+
+class Receipt
+{
+    private $receipt;
+
+    public function __construct($receipt = null)
+    {
+        $this->receipt = $receipt;
+    }
+
+    public function getReceipt()
+    {
+        return $this->receipt;
+    }
+
+    public function setReceipt($receipt)
+    {
+        $this->receipt = $receipt;
+    }
+
+    public function hasReceipt()
+    {
+        return !is_null($this->receipt);
+    }
+}

--- a/src/LeonardoTeixeira/Pushover/Status.php
+++ b/src/LeonardoTeixeira/Pushover/Status.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace LeonardoTeixeira\Pushover;
+
+use LeonardoTeixeira\Pushover\Exceptions\InvalidArgumentException;
+
+class Status
+{
+    const ACKNOWLEDGED = 'acknowledged';
+    const ACKNOWLEDGED_AT = 'acknowledged_at';
+    const ACKNOWLEDGED_BY = 'acknowledged_by';
+    const ACKNOWLEDGED_BY_DEVICE = 'acknowledged_by_device';
+    const LAST_DELIVERED_AT = 'last_delivered_at';
+    const EXPIRED = 'expired';
+    const EXPIRED_AT = 'expires_at';
+    const CALLED_BACK = 'called_back';
+    const CALLED_BACK_AT = 'called_back_at';
+    
+    private $status = [
+            self::ACKNOWLEDGED => null,
+            self::ACKNOWLEDGED_AT => null,
+            self::ACKNOWLEDGED_BY => null,
+            self::ACKNOWLEDGED_BY_DEVICE => null,
+            self::LAST_DELIVERED_AT => null,
+            self::EXPIRED => null,
+            self::EXPIRED_AT => null,
+            self::CALLED_BACK => null,
+            self::CALLED_BACK_AT => null
+        ];
+
+    public function __construct($status = null)
+    {
+        if(!is_null($status)) {
+            if(!is_array($status))
+                throw new InvalidArgumentException('The status \'' . $status . '\' is invalid.');
+            
+            foreach($status as $key => $value) {
+                if(array_key_exists($key, $this->status)) {
+                    $this->status[$key] = $value;
+                }
+            }
+        }
+    }
+ 
+    public function setAcknowledged($value)
+    {
+        $this->status[self::ACKNOWLEDGED] = $value;
+    }  
+      
+    public function setAcknowledgedAt($value)
+    {
+        $this->status[self::ACKNOWLEDGED_AT] = $value;
+    }  
+    
+    public function setAcknowledgedBy($value)
+    {
+        $this->status[self::ACKNOWLEDGED_BY] = $value;
+    }  
+       
+    public function setAcknowledgedByDevice($value)
+    {
+        $this->status[self::ACKNOWLEDGED_BY_DEVICE] = $value;
+    }  
+           
+    public function setLastDeliveredAt($value)
+    {
+        $this->status[self::LAST_DELIVERED_AT] = $value;
+    }  
+            
+    public function setExpired($value)
+    {
+        $this->status[self::EXPIRED] = $value;
+    } 
+    
+    public function setExpiredAt($value)
+    {
+        $this->status[self::EXPIRED_AT] = $value;
+    }     
+
+    public function setCalledBack($value)
+    {
+        $this->status[self::CALLED_BACK] = $value;
+    }  
+    
+    public function setCalledBackAt($value)
+    {
+        $this->status[self::CALLED_BACK_AT] = $value;
+    }  
+ 
+    public function getAcknowledged()
+    {
+        return $this->status[self::ACKNOWLEDGED];
+    }  
+      
+    public function getAcknowledgedAt()
+    {
+        return $this->status[self::ACKNOWLEDGED_AT];
+    }  
+    
+    public function getAcknowledgedBy()
+    {
+        return $this->status[self::ACKNOWLEDGED_BY];
+    }  
+       
+    public function getAcknowledgedByDevice()
+    {
+        return $this->status[self::ACKNOWLEDGED_BY_DEVICE];
+    }  
+           
+    public function getLastDeliveredAt()
+    {
+        return $this->status[self::LAST_DELIVERED_AT];
+    }  
+            
+    public function getExpired()
+    {
+        return $this->status[self::EXPIRED];
+    } 
+    
+    public function getExpiredAt()
+    {
+        return $this->status[self::EXPIRED_AT];
+    }     
+
+    public function getCalledBack()
+    {
+        return $this->status[self::CALLED_BACK];
+    }  
+    
+    public function getCalledBackAt()
+    {
+        return $this->status[self::CALLED_BACK_AT];
+    } 
+ 
+    public function hasAcknowledged()
+    {
+        return !is_null($this->status[self::ACKNOWLEDGED]);
+    }  
+      
+    public function hasAcknowledgedAt()
+    {
+        return !is_null($this->status[self::ACKNOWLEDGED_AT]);
+    }  
+    
+    public function hasAcknowledgedBy()
+    {
+        return !is_null($this->status[self::ACKNOWLEDGED_BY]);
+    }  
+       
+    public function hasAcknowledgedByDevice()
+    {
+        return !is_null($this->status[self::ACKNOWLEDGED_BY_DEVICE]);
+    }  
+           
+    public function hasLastDeliveredAt()
+    {
+        return !is_null($this->status[self::LAST_DELIVERED_AT]);
+    }  
+            
+    public function hasExpired()
+    {
+        return !is_null($this->status[self::EXPIRED]);
+    } 
+    
+    public function hasExpiredAt()
+    {
+        return !is_null($this->status[self::EXPIRED_AT]);
+    }     
+
+    public function hasCalledBack()
+    {
+        return !is_null($this->status[self::CALLED_BACK]);
+    }  
+    
+    public function hasCalledBackAt()
+    {
+        return !is_null($this->status[self::CALLED_BACK_AT]);
+    }     
+}


### PR DESCRIPTION
With the pull, we can
- poll the receipts API #4 
- cancel emergencies
- and send images as attachements (introduced with Pushover V3.0)