### PR TITLE
Add support for Pushover Glances API

### DIFF
--- a/src/LeonardoTeixeira/Pushover/Client.php
+++ b/src/LeonardoTeixeira/Pushover/Client.php
@@ -200,7 +200,74 @@ class Client
     }
     
     
-    public function pushGlance(Glances $glances, $device = null)
+    public function updateGlances(Glances $glances, $device = null)
+    {
+        if (!$glances->hasTitle() && !$glances->hasText() && !$glances->hasSubtext() && !$glances->hasCount() && !$glances->hasPercent()) {
+            throw new PushoverException('The parameter \'$glances\' must have at least one parameter');
+        }
+
+        $postData = [
+            'user' => $this->user,
+            'token' => $this->token
+        ];
+
+        if ($device != null) {
+            $postData['device'] = $device;
+        }
+
+        if ($glances->hasTitle()) {
+            $postData['title'] = $glances->getTitle();
+        }
+
+        if ($glances->hasText()) {
+            $postData['text'] = $glances->getText();
+        }
+
+        if ($glances->hasSubtext()) {
+            $postData['subtext'] = $glances->getSubtext();
+        }
+
+        if ($glances->hasCount()) {
+            $postData['count'] = $glances->getCount();
+        }
+
+        if ($glances->hasPercent()) {
+            $postData['percent'] = $glances->getPercent();
+        }
+
+        try {
+         // Using hooks is an ugly hack since we bypass the fancy request API
+         // Up to no, Requests doesn't support multi-part headers :-/
+         //
+         // Should we switch to guzzle/guzzle ?
+         $hooks = new Requests_Hooks();
+         $hooks->register('curl.before_send', function($fp) use ($postData) {
+         curl_setopt($fp, CURLOPT_POSTFIELDS, $postData);
+         $postData = [];
+            });
+            $hooks = ['hooks' => $hooks];
+
+            $request = Requests::post(self::API_GLANCES_URL, [], $postData, $hooks);
+            $responseJson = json_decode($request->body);
+
+            if (!isset($responseJson->status) || $responseJson->status != 1) {
+                if (isset($responseJson->errors)) {
+                    throw new PushoverException($responseJson->errors[0]);
+                } else {
+                    throw new PushoverException('Unable to access the Pushover API.');
+                }
+            }
+            if(isset($responseJson->receipt)) {
+                return new Receipt($responseJson->receipt);
+            }
+            return new Receipt();
+
+        } catch (\Exception $e) {
+            throw new PushoverException($e->getMessage());
+        }
+    }
+    
+     public function updateGlances(Glances $glances, $device = null)
     {
         if (!$glances->hasTitle() && !$glances->hasText() && !$glances->hasSubtext() && !$glances->hasCount() && !$glances->hasPercent()) {
             throw new PushoverException('The parameter \'$glances\' must have at least one parameter');

--- a/src/LeonardoTeixeira/Pushover/Glances.php
+++ b/src/LeonardoTeixeira/Pushover/Glances.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace LeonardoTeixeira\Pushover;
+
+use LeonardoTeixeira\Pushover\Exceptions\InvalidArgumentException;
+
+class Glances
+{
+    private $title;   //(100 characters) - a description of the data being shown, such as "Widgets Sold"
+    private $text;    //(100 characters) - the main line of data, used on most screens
+    private $subtext; //(100 characters) - a second line of data
+    private $count;   //(integer, may be negative) - shown on smaller screens; useful for simple counts
+    private $percent; //(integer 0 through 100, inclusive) - shown on some screens as a progress bar/circle
+
+	private $attachment;
+	
+    public function __construct()
+    {
+        $this->title = null;
+        $this->text = null;
+        $this->subtext = null;
+        $this->count = null;
+        $this->percent = null;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    public function getText()
+    {
+        return $this->text;
+    }
+
+    public function getSubtext()
+    {
+        return $this->subtext;
+    }
+
+    public function getCount()
+    {
+        return $this->count;
+    }
+
+    public function getPercent()
+    {
+        return $this->percent;
+    }
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    public function setText($text)
+    {
+        $this->url = $text;
+    }
+
+    public function setSubtext($subtext)
+    {
+        $this->urlTitle = $subtext;
+    }
+
+    public function setCount($count)
+    {
+        $this->retry = $count;
+    }
+
+    public function setPercent($percent)
+    {
+        if ($percent < 0 || $percent > 100) {
+          throw new InvalidArgumentException('The percent value \'' . $percent . '\' is out of range.');
+        }
+        $this->percent = $percent;
+    }
+
+    public function hasTitle()
+    {
+        return !is_null($this->title);
+    }
+
+    public function hasText()
+    {
+        return !is_null($this->text);
+    }
+
+    public function hasSubtext()
+    {
+        return !is_null($this->subtext);
+    }
+
+    public function hasCount()
+    {
+        return !is_null($this->count);
+    }
+
+    public function hasPercent()
+    {
+        return !is_null($this->percent);
+    }
+}


### PR DESCRIPTION
For more details see [Pushover Glances API](https://pushover.net/api/glances)

But one part needs to mentioned here:
Updating Data
It's important to note that our Glances API stores the current state of all available fields for a given screen and only discards data when the field is overwritten by your API call. If your API call only updates one field of data, the other fields will retain the data from your previous calls. This is useful for using our API to aggregate data from multiple, independent sources and collecting it all on the destination screen.